### PR TITLE
Util/Command updated

### DIFF
--- a/VersionControl/Git/Util/Command.php
+++ b/VersionControl/Git/Util/Command.php
@@ -185,7 +185,7 @@ class VersionControl_Git_Util_Command extends VersionControl_Git_Component
             }
 
             if (true !== $v) {
-                $command .= '='.escapeshellarg($v);
+                $command .= ' '.escapeshellarg($v);
             }
         }
 


### PR DESCRIPTION
Util/Command updated to support --opt value, instead of --opt=value.

Tested on git 1.7.0.4:
git tag mytag -F=/tmp/tagmessage.txt 

Results in error "=/tmp/tagmessage.txt" not found (note the = sign in message). Once updated:

git tag mytag -F /tmp/tagmessage.txt 
Works flawlessly.
