### PR TITLE
Allow VersionControl_Git_Object_Tree::fetch() to get all objects on all systems

### DIFF
--- a/VersionControl/Git/Object/Tree.php
+++ b/VersionControl/Git/Object/Tree.php
@@ -71,9 +71,9 @@ class VersionControl_Git_Object_Tree extends VersionControl_Git_Object implement
     public function fetch()
     {
         $command = $this->git->getCommand('ls-tree')
-            ->addArgument($this->id);
+            ->addArgument('-z')->addArgument($this->id);
 
-        $lines = explode(PHP_EOL, trim($command->execute()));
+        $lines = explode("\0", trim($command->execute()));
         foreach ($lines as $line) {
             $itemString = str_replace("\t", ' ', $line);
 


### PR DESCRIPTION
On my system (Windows 10), _VersionControl_Git_Object_Tree::fetch()_ returns only the first object, because PHP_EOL is different from EOL in text returned by GIT. I resolved the problem using argument '-z'. This should work on any other operating system.