### PR TITLE
Fixes Tree::seek() execution on PHP 8.1

### DIFF
--- a/VersionControl/Git/Object/Tree.php
+++ b/VersionControl/Git/Object/Tree.php
@@ -94,6 +94,7 @@ class VersionControl_Git_Object_Tree extends VersionControl_Git_Object implement
      *
      * @return null
      */
+    #[ReturnTypeWillChange]
     public function seek($position)
     {
         $this->position = $position;


### PR DESCRIPTION
When executing Tree::seek() on PHP 8.1 there will be a fatal error.

```
PHP Fatal error:  During inheritance of SeekableIterator: Uncaught Return type of VersionControl_Git_Object_Tree::seek($position)
should either be compatible with SeekableIterator::seek(int $offset): void, or the #[ReturnTypeWillChange] attribute should be
used to temporarily suppress the notice
```